### PR TITLE
fix: Make tools that set `result_as_answer=True` return their raw string output as the final answer

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -477,7 +477,9 @@ class Agent(BaseAgent):
         # result_as_answer set to True
         for tool_result in self.tools_results:  # type: ignore # Item "None" of "list[Any] | None" has no attribute "__iter__" (not iterable)
             if tool_result.get("result_as_answer", False):
-                result = tool_result["result"]
+                from crewai.tools.tool_types import ToolAnswerResult
+                result = ToolAnswerResult(tool_result["result"])  # type: ignore
+                # result = tool_result["result"]
         crewai_event_bus.emit(
             self,
             event=AgentExecutionCompletedEvent(agent=self, task=task, output=result),

--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -38,6 +38,7 @@ from crewai.security import Fingerprint, SecurityConfig
 from crewai.tasks.output_format import OutputFormat
 from crewai.tasks.task_output import TaskOutput
 from crewai.tools.base_tool import BaseTool
+from crewai.tools.tool_types import ToolAnswerResult
 from crewai.utilities.config import process_config
 from crewai.utilities.constants import NOT_SPECIFIED, _NotSpecified
 from crewai.utilities.guardrail import process_guardrail, GuardrailResult
@@ -425,6 +426,7 @@ class Task(BaseModel):
 
             self.processed_by_agents.add(agent.role)
             crewai_event_bus.emit(self, TaskStartedEvent(context=context, task=self))
+            
             result = agent.execute_task(
                 task=self,
                 context=context,
@@ -432,11 +434,14 @@ class Task(BaseModel):
             )
 
             pydantic_output, json_output = self._export_output(result)
+            
+            raw_result = result.result if hasattr(result, 'result') else result
+
             task_output = TaskOutput(
                 name=self.name,
                 description=self.description,
                 expected_output=self.expected_output,
-                raw=result,
+                raw=raw_result,
                 pydantic=pydantic_output,
                 json_dict=json_output,
                 agent=agent.role,
@@ -714,8 +719,11 @@ Follow these guidelines:
         return copied_task
 
     def _export_output(
-        self, result: str
+        self, result: Union[str, ToolAnswerResult]
     ) -> Tuple[Optional[BaseModel], Optional[Dict[str, Any]]]:
+        if isinstance(result, ToolAnswerResult):
+            return None, None
+
         pydantic_output: Optional[BaseModel] = None
         json_output: Optional[Dict[str, Any]] = None
 

--- a/src/crewai/tools/tool_types.py
+++ b/src/crewai/tools/tool_types.py
@@ -7,3 +7,12 @@ class ToolResult:
 
     result: str
     result_as_answer: bool = False
+
+class ToolAnswerResult:
+    """Wrapper for tool results that should be used as final answers without conversion."""
+
+    def __init__(self, result: str):
+        self.result = result
+
+    def __str__(self) -> str:
+        return self.result

--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -311,6 +311,7 @@ class ToolUsage:
             hasattr(available_tool, "result_as_answer")
             and available_tool.result_as_answer  # type: ignore # Item "None" of "Any | None" has no attribute "cache_function"
         ):
+            raise Exception("Did I hit this?")
             result_as_answer = available_tool.result_as_answer  # type: ignore # Item "None" of "Any | None" has no attribute "result_as_answer"
             data["result_as_answer"] = result_as_answer  # type: ignore
 

--- a/src/crewai/tools/tool_usage.py
+++ b/src/crewai/tools/tool_usage.py
@@ -286,6 +286,12 @@ class ToolUsage:
             tool_name=tool.name,
             attempts=self._run_attempts,
         )
+        # Skip formatting if result_as_answer is True
+        if (
+            hasattr(available_tool, "result_as_answer")
+            and available_tool.result_as_answer
+        ):
+            return result
         result = self._format_result(result=result)  # type: ignore # "_format_result" of "ToolUsage" does not return a value (it only ever returns None)
         data = {
             "result": result,

--- a/tests/tools/test_tool_result_as_answer.py
+++ b/tests/tools/test_tool_result_as_answer.py
@@ -1,32 +1,241 @@
-from crewai import Agent, Task, Crew
-from crewai.tools import tool
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from crewai.agent import Agent
+from crewai.crew import Crew
+from crewai.task import Task
+from crewai.tools.base_tool import BaseTool
+from crewai.tools.tool_types import ToolAnswerResult
+from pydantic import BaseModel
 
-@tool("Simple Echo")
-def echo_tool():
-    """Clear description for what this tool is useful for, your agent will need this information to use it."""
-    return "TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED"
 
-def test_tool_result_as_answer_bypasses_formatting():
-    with patch("crewai.llms.base_llm.BaseLLM.call") as mock_call:
-        mock_call.return_value = "Final Answer: TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED"
+class outputModel(BaseModel):
+    message: str
+    status: str
 
-        agent = Agent(
-            role="tester",
-            goal="test result_as_answer",
-            backstory="You're just here to echo things.",
-            tools=[echo_tool],
-            verbose=False
-        )
 
-        task = Task(
-            description="Echo something",
-            agent=agent,
-            expected_output="TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED",
-            result_as_answer=True
-        )
+class MockTool(BaseTool):
+    name: str = "mock_tool"
+    description: str = "A mock tool for testing"
+    result_as_answer: bool = False
 
-        # crew = Crew(tasks=[task])
-        result = echo_tool.run()
+    def _run(self, *args, **kwargs) -> str:
+        return "Mock tool output"
 
-        assert result == "TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED"
+
+class MockLLM:
+    def call(self, messages, **kwargs):
+        return "LLM processed output"
+
+    def __call__(self, messages, **kwargs):
+        return self.call(messages, **kwargs)
+
+def test_tool_with_result_as_answer_true_bypasses_conversion():
+    """Test that tools with result_as_answer=True return output without conversion."""
+    tool = MockTool()
+    tool.result_as_answer = True
+
+    agent = Agent(
+        role="test_agent",
+        goal="test goal",
+        backstory="test backstory",
+        llm=MockLLM(),
+        tools=[tool]
+    )
+
+    task = Task(
+        description="Test task",
+        expected_output="Test output",
+        agent=agent,
+        output_pydantic=outputModel
+    )
+
+    agent.tools_results = [
+        {
+            "tool": "mock_tool",
+            "result": "Plain string output that should not be converted",
+            "result_as_answer": True
+        }
+    ]
+    
+    
+    with patch.object(Agent, "execute_task", return_value=ToolAnswerResult(
+        "Plain string output that should not be converted"
+    )):
+        result = task.execute_sync()
+
+    assert result.raw == "Plain string output that should not be converted"
+    assert result.pydantic is None
+    assert result.json_dict is None
+
+
+def test_tool_with_result_as_answer_false_applies_conversion():
+    """Test that tools with result_as_answer=False still apply conversion when output_pydantic is set."""
+    tool = MockTool()
+    tool.result_as_answer = False
+
+    agent = Agent(
+        role="test_agent",
+        goal="test goal", 
+        backstory="test backstory",
+        llm=MockLLM(),
+        tools=[tool]
+    )
+
+    task = Task(
+        description="Test task",
+        expected_output="Test output",
+        agent=agent,
+        output_pydantic=outputModel
+    )
+
+    with patch.object(agent, 'execute_task') as mock_execute:
+        mock_execute.return_value = '{"message": "test", "status": "success"}'
+
+        with patch('crewai.task.convert_to_model') as mock_convert:
+            mock_convert.return_value = outputModel(message="test", status="success")
+
+            result = task.execute_sync()
+
+            assert mock_convert.called
+            assert result.pydantic is not None
+            assert isinstance(result.pydantic, outputModel)
+
+
+def test_multiple_tools_last_result_as_answer_wins():
+    """Test that when multiple tools are used, the last one with result_as_answer=True is used."""
+    agent = Agent(
+        role="test_agent",
+        goal="test goal",
+        backstory="test backstory", 
+        llm=MockLLM()
+    )
+
+    task = Task(
+        description="Test task",
+        expected_output="Test output",
+        agent=agent
+    )
+
+    agent.tools_results = [
+        {
+            "tool": "tool1",
+            "result": "First tool output",
+            "result_as_answer": False
+        },
+        {
+            "tool": "tool2", 
+            "result": "Second tool output",
+            "result_as_answer": True
+        },
+        {
+            "tool": "tool3",
+            "result": "Third tool output", 
+            "result_as_answer": False
+        },
+        {
+            "tool": "tool4",
+            "result": "Final tool output that should be used",
+            "result_as_answer": True
+        }
+    ]
+
+    with patch.object(agent, 'execute_task') as mock_execute:
+        mock_execute.return_value = ToolAnswerResult("Final tool output that should be used")
+
+        result = task.execute_sync()
+
+        assert result.raw == "Final tool output that should be used"
+
+
+def test_tool_answer_result_wrapper():
+    """Test the ToolAnswerResult wrapper class."""
+    result = ToolAnswerResult("test output")
+
+    assert str(result) == "test output"
+
+    assert result.result == "test output"
+
+
+def test_reproduction_of_issue_3335():
+    """Reproduction test for GitHub issue #3335."""
+
+    tool = MockTool()
+    tool.result_as_answer = True
+
+    def mock_tool_run(*args, **kwargs):
+        return "This is a plain string that should not be converted to JSON"
+
+    tool._run = mock_tool_run
+
+    agent = Agent(
+        role="test_agent",
+        goal="test goal",
+        backstory="test backstory",
+        llm=MockLLM(),
+        tools=[tool]
+    )
+
+    task = Task(
+        description="Test task",
+        expected_output="Test output", 
+        agent=agent,
+        output_pydantic=outputModel
+    )
+
+    agent.tools_results = [
+        {
+            "tool": "mock_tool",
+            "result": "This is a plain string that should not be converted to JSON",
+            "result_as_answer": True
+        }
+    ]
+
+    with patch.object(agent, 'execute_task') as mock_execute:
+        mock_execute.return_value = ToolAnswerResult("This is a plain string that should not be converted to JSON")
+
+        result = task.execute_sync()
+
+        assert result.raw == "This is a plain string that should not be converted to JSON"
+        assert result.pydantic is None
+        assert result.json_dict is None
+
+
+def test_edge_case_complex_tool_output():
+    """Test edge case with complex tool output that should be preserved."""
+    complex_output = """
+    This is a multi-line output
+    with special characters: !@#$%^&*()
+    and some JSON-like content: {"key": "value"}
+    but it should be preserved as-is when result_as_answer=True
+    """
+
+    agent = Agent(
+        role="test_agent", 
+        goal="test goal",
+        backstory="test backstory",
+        llm=MockLLM()
+    )
+
+    task = Task(
+        description="Test task",
+        expected_output="Test output",
+        agent=agent,
+        output_pydantic=outputModel
+    )
+
+    agent.tools_results = [
+        {
+            "tool": "complex_tool",
+            "result": complex_output,
+            "result_as_answer": True
+        }
+    ]
+
+    with patch.object(agent, 'execute_task') as mock_execute:
+        mock_execute.return_value = ToolAnswerResult(complex_output)
+
+        result = task.execute_sync()
+
+        assert result.raw == complex_output
+        assert result.pydantic is None
+        assert result.json_dict is None
+        

--- a/tests/tools/test_tool_result_as_answer.py
+++ b/tests/tools/test_tool_result_as_answer.py
@@ -1,0 +1,32 @@
+from crewai import Agent, Task, Crew
+from crewai.tools import tool
+from unittest.mock import patch
+
+@tool("Simple Echo")
+def echo_tool():
+    """Clear description for what this tool is useful for, your agent will need this information to use it."""
+    return "TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED"
+
+def test_tool_result_as_answer_bypasses_formatting():
+    with patch("crewai.llms.base_llm.BaseLLM.call") as mock_call:
+        mock_call.return_value = "Final Answer: TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED"
+
+        agent = Agent(
+            role="tester",
+            goal="test result_as_answer",
+            backstory="You're just here to echo things.",
+            tools=[echo_tool],
+            verbose=False
+        )
+
+        task = Task(
+            description="Echo something",
+            agent=agent,
+            expected_output="TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED",
+            result_as_answer=True
+        )
+
+        # crew = Crew(tasks=[task])
+        result = echo_tool.run()
+
+        assert result == "TOOL_OUTPUT_SHOULD_NOT_BE_CHANGED"


### PR DESCRIPTION
## Summary

Add a ToolAnswerResult wrapper and plumbing so tools that set result_as_answer=True return their raw string output as the final answer (skipping pydantic/json conversion and schema parsing).

Fix for Issue #3335: when a tool returns a plain string but sets result_as_answer=True (meaning the tool’s raw output should be used directly), the framework still attempted to convert/validate it into pydantic/json output. That caused incorrect parsing/validation and lost the intended raw-string answer. This PR prevents that conversion path for those cases.

##Key changes (files / behavior)

### New type and behavior control
`src/crewai/tools/tool_types.py`
Adds ToolAnswerResult wrapper class (stores raw result and stringifies).

### Agent / execution flow
`src/crewai/agent.py`
When iterating tools_results, if a tool result was marked result_as_answer the code now wraps the returned value with ToolAnswerResult before emitting AgentExecutionCompletedEvent.
`src/crewai/task.py`
Task._execute_core: when receiving agent result, capture raw_result from ToolAnswerResult so TaskOutput.raw holds the raw string.
Task._export_output: if result is a ToolAnswerResult, return (None, None) for pydantic/json outputs (skip conversion).

### Tool usage

`src/crewai/tools/tool_usage.py`
Skip formatting when an available tool has result_as_answer True (so formatter/conversion paths are bypassed).

### Tests

Added `tests/tools/test_tool_result_as_answer.py` with multiple unit tests validating:
- a tool with result_as_answer=True bypasses conversion and leaves pydantic/json None,
- normal conversion still works when result_as_answer=False,
- last tool with result_as_answer=True wins,
- ToolAnswerResult wrapper behaves as expected,
- edge case outputs preserved,
- reproduction test for issue #3335.
- Small test cleanups across multiple test files (removed unused imports, made some tests commented/skipped).
- Minor bugfixes / cleanups
- src/crewai/agents/agent_adapters/langgraph/structured_output_converter.py
- More specific exception handling (catch ValueError instead of broad except) when JSON decoding/extraction fails.
- Several files: removed unused imports, cleaned typing imports, and small refactors (flow/path_utils, html_template_handler, etc.).

## Behavioral impact

- Tools that intentionally mark their outputs as final answers will now bypass conversion and be returned verbatim:
TaskOutput.raw will contain the exact string returned by the tool.
- TaskOutput.pydantic and TaskOutput.json_dict will be None for those outputs, preventing accidental schema validation or JSON extraction.
- Existing tasks that rely on conversion remain unchanged (result_as_answer False).
- Potential issues / review items

`src/crewai/tools/tool_types.py`: file ends with "No newline at end of file" in the diff — consider adding trailing newline for style.
`src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py`: commented out import (ToolMessage) — confirm intentional.
Ensure all callers that previously expected pydantic/json outputs handle the ToolAnswerResult case (Task._export_output now returns (None, None) — callers should expect that).
Run full test suite and CI to ensure no regressions; PR already introduces tests that validate the new behavior but double-check integration paths (delegation, agent events, and any consumers of TaskOutput.json_dict).

## Note for reviewers 

### Suggested reviewers

Anyone responsible for tool execution and task output conversion (agents, tools, task serialization), and maintainers familiar with issue #3335.

### Checklist

- Confirm the goal: tools that set result_as_answer=True should return their raw string as the final answer, bypassing pydantic/json conversion and schema parsing.

- Key files to review (changes & behavior)

`src/crewai/tools/tool_types.py`
Validate ToolAnswerResult implementation and str behavior.

`src/crewai/agent.py`
Confirm wrapping of tool result with ToolAnswerResult when result_as_answer True (lines added where AgentExecutionCompletedEvent emitted).

`src/crewai/task.py`
Verify Task._execute_core uses ToolAnswerResult to populate TaskOutput.raw and that Task._export_output returns (None, None) for ToolAnswerResult.
Ensure no callers assume pydantic/json are always present after this change.

`src/crewai/agents/agent_adapters/langgraph/structured_output_converter.py`
Confirm the narrower exception handling (catch ValueError) is correct for JSON decode/validate extraction.

### Tests: 
`tests/tools/test_tool_result_as_answer.py`
Review test coverage, edge cases, and mocking approach; ensure tests reflect intended behaviour and are not masking other issues.

### Functional checks to perform locally

#### Run unit tests:
```
pytest tests/tools/test_tool_result_as_answer.py -q
pytest -q (or full suite) to detect regressions
```

#### Manually exercise a task where:
- A tool returns a plain string and result_as_answer=True → expect TaskOutput.raw == exact string, pydantic/json None.
- A tool returns JSON-like string but result_as_answer=True → ensure raw preserved (no parsing).
- A tool returns a valid JSON and result_as_answer=False with output_pydantic set → ensure conversion still occurs.
- Run any integration flows that previously relied on TaskOutput.json_dict/pydantic to ensure they gracefully handle None.

#### Edge cases & defensive questions

- Multiple tools: confirm "last tool with result_as_answer True wins" behavior is intentional and documented.
- Consumers: search for code paths that assume TaskOutput.pydantic or json_dict are non-None — these may need guard clauses.
- Event consumers: verify listeners of AgentExecutionCompletedEvent and TaskStartedEvent handle ToolAnswerResult payloads correctly.
- Type annotations: ensure new ToolAnswerResult type is properly typed/imported where needed to avoid mypy/typing issues.
- Logging/observability: ensure the raw tool answers are not inadvertently leaked in logs (sensitive outputs).

#### Test & CI expectations

- New unit tests must pass (tests/tools/test_tool_result_as_answer.py).
- Run full test suite on CI and confirm no flakiness introduced by mocking or commented tests.

#### Suggested follow-ups (if approved)
- Add a small integration test (optional) that simulates a real tool returning a string with result_as_answer True.
- Add a short note in CHANGELOG / PR description describing the behavioral change (tools can now return raw answers).
- Add unit tests for event listeners that may consume ToolAnswerResult.